### PR TITLE
Add support for EE 3.x

### DIFF
--- a/system/expressionengine/third_party/wygwam_enhanced_img/addon.setup.php
+++ b/system/expressionengine/third_party/wygwam_enhanced_img/addon.setup.php
@@ -1,0 +1,12 @@
+<?php  if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+return array(
+    'author'      => 'Nathan Doyle',
+    'author_url'  => 'http://github.com/Natetronn/wygwam_enhanced_image',
+    'name'        => 'Wygwam Enhanced Image',
+    'description' => '',
+    'version'     => '0.3',
+    'namespace'   => '\\',
+    'settings_exist' => TRUE,
+    'docs_url' => 'http://github.com/Natetronn/wygwam_enhanced_image',
+);

--- a/system/expressionengine/third_party/wygwam_enhanced_img/ext.wygwam_enhanced_img.php
+++ b/system/expressionengine/third_party/wygwam_enhanced_img/ext.wygwam_enhanced_img.php
@@ -14,11 +14,11 @@
 
 class Wygwam_enhanced_img_ext
 {
-    
+
     private static $_included_resources = FALSE;
 
     var $name           = 'Wygwam Enhanced Image';
-    var $version        = '0.2';
+    var $version        = '0.3';
     var $description    = '';
     var $docs_url       = 'http://github.com/Natetronn/wygwam_enhanced_image';
     var $settings_exist = 'y';
@@ -37,11 +37,10 @@ class Wygwam_enhanced_img_ext
      */
     public function __construct($settings = '')
     {
-        $this->EE =& get_instance();
         $this->settings = $settings;
         $this->theme_url    = defined( 'URL_THIRD_THEMES' )
                             ? URL_THIRD_THEMES . 'wygwam_enhanced_img/'
-                            : $this->EE->config->item('theme_folder_url') . 'third_party/wygwam_enhanced_img/';
+                            : ee()->config->item('theme_folder_url') . 'third_party/wygwam_enhanced_img/';
     }
 
     /**
@@ -50,7 +49,7 @@ class Wygwam_enhanced_img_ext
      */
     public function activate_extension()
     {
-        
+
         $this->settings = array(
             'imageresponsive'   => FALSE,
             'inline_or_class'   => "inline",


### PR DESCRIPTION
This adds support for EE 3.x by:

- Adding the new required setup file
- Transitioning to use the `ee()` function.

This changes should preserve backwards compatibility with 2.x, [at least, back to 2.6](https://expressionengine.stackexchange.com/q/20802/7405).

As part of these changes, I also increased the version to `0.3`. I figured some sort of increase was appropriate. 😅 

I tested both the "inline" and "class" configurations on my local site and they both appear to be working great:

![image](https://user-images.githubusercontent.com/1256329/51945465-d1c34480-23ec-11e9-9c53-84411d942cef.png)


